### PR TITLE
Replace libc::...::c_ulong with libc::c_ulong

### DIFF
--- a/src/mach/types.rs
+++ b/src/mach/types.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use libc::types::os::arch::c95::c_ulong;
+use libc::c_ulong;
 
 pub struct LoadCommand {
     pub cmd: u32,


### PR DESCRIPTION
This patch updates execfmt for compatibility with Rust nightly-2015-08-01